### PR TITLE
fix golang image tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine3.20 AS builder
+FROM golang:1.23-alpine3.20 AS builder
 
 RUN mkdir /app && mkdir -p /usr/local/src/smolgit
 WORKDIR /usr/local/src/smolgit


### PR DESCRIPTION
Fixes #8  not working `build-docker` command (#8)

## Proposed Changes

  - Changed tag of base golang image